### PR TITLE
- changed Queue in Validator class to carry unique values in "validated" variable

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,4 +3,7 @@
   <component name="ProjectRootManager">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
+  <component name="ProjectType">
+    <option name="id" value="jpab" />
+  </component>
 </project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/Compiler/src/core/Validator.java
+++ b/Compiler/src/core/Validator.java
@@ -9,7 +9,11 @@ import java.util.Set;
 
 public class Validator {
 
-    private Queue<Statement> validated = new LinkedList<>();
+    private Queue<Statement> validated = new LinkedList<>(){
+       @Override
+        public boolean offer(Statement e) { return !this.contains(e) && super.add(e);}
+    };
+
     private Queue<Statement> nonValidated;
 
     private Set<String> variables = new HashSet<>();


### PR DESCRIPTION
I have changed Queue in Validator class to only carry unique values in "validated" variable.

Given the need to compare values in the validated queue (to check for duplicates), it seems more reasonable to override the offer method than it would be to create a new class that will implement a UniqueElements queue.

We are provided with the ability to save unique Statements in a queue, order is kept intact, and we do not depend on another class.

The Statements class already has an overridden "equals" method (in which comparison is made by variables in the class, rather than Object Identifier)  which fits well into our "contains" comparison.